### PR TITLE
Bug fixes for issues 8 & 9

### DIFF
--- a/Engine/ViewModels/GameSession.cs
+++ b/Engine/ViewModels/GameSession.cs
@@ -75,6 +75,7 @@ namespace Engine.ViewModels
                 {
                     _currentBattle.OnCombatVictory -= OnCurrentMonsterKilled;
                     _currentBattle.Dispose();
+                    _currentBattle = null;
                 }
 
                 _currentMonster = value;
@@ -268,8 +269,23 @@ namespace Engine.ViewModels
         {
             if(CurrentPlayer.CurrentConsumable != null)
             {
+                if (_currentBattle == null)
+                {
+                    CurrentPlayer.OnActionPerformed += OnConsumableActionPerformed;
+                }
+
                 CurrentPlayer.UseCurrentConsumable();
+
+                if (_currentBattle == null)
+                {
+                    CurrentPlayer.OnActionPerformed -= OnConsumableActionPerformed;
+                }
             }
+        }
+
+        private void OnConsumableActionPerformed(object sender, string result)
+        {
+            _messageBroker.RaiseMessage(result);
         }
 
         public void CraftItemUsing(Recipe recipe)

--- a/Engine/ViewModels/GameSession.cs
+++ b/Engine/ViewModels/GameSession.cs
@@ -261,7 +261,7 @@ namespace Engine.ViewModels
 
         public void AttackCurrentMonster()
         {
-            _currentBattle.AttackOpponent();
+            _currentBattle?.AttackOpponent();
         }
 
         public void UseCurrentConsumable()


### PR DESCRIPTION
Fix issue #8 - When there isn't a current battle, no OnActionPerformed handler is registered.
Fix issue #9 - Ensure there is a _currentBattle before calling AttackOpponent.