### PR TITLE
Combat improvements flee attack of opportunity

### DIFF
--- a/SOSCSRPG.Models/Battle.cs
+++ b/SOSCSRPG.Models/Battle.cs
@@ -53,6 +53,14 @@ namespace SOSCSRPG.Models
             }
         }
 
+        public void PlayerAttemptToEscapeCombat()
+        {
+            _messageBroker.RaiseMessage("");
+            _messageBroker.RaiseMessage($"You attempt to flee from {_opponent.Name}.");
+
+            AttackPlayer();
+        }
+
         public void Dispose()
         {
             _player.OnActionPerformed -= OnCombatantActionPerformed;

--- a/SOSCSRPG.Models/Battle.cs
+++ b/SOSCSRPG.Models/Battle.cs
@@ -29,7 +29,7 @@ namespace SOSCSRPG.Models
             _opponent.OnKilled += OnOpponentKilled;
 
             _messageBroker.RaiseMessage("");
-            _messageBroker.RaiseMessage($"You see a {_opponent.Name} here!");
+            _messageBroker.RaiseMessage($"A {_opponent.Name} appears!");
 
             if(FirstAttacker(_player, _opponent) == Combatant.Opponent)
             {

--- a/SOSCSRPG.ViewModels/GameSession.cs
+++ b/SOSCSRPG.ViewModels/GameSession.cs
@@ -193,37 +193,44 @@ namespace SOSCSRPG.ViewModels
             _messageBroker.OnMessageRaised += OnGameMessageRaised;
         }
 
-        public void MoveNorth()
+        public void AttemptMoveNorth()
         {
             if(HasLocationToNorth)
             {
-                CurrentLocation = CurrentWorld.LocationAt(CurrentLocation.XCoordinate, CurrentLocation.YCoordinate + 1);
+				MoveTo(CurrentLocation.XCoordinate, CurrentLocation.YCoordinate + 1);
             }
         }
 
-        public void MoveEast()
+        public void AttemptMoveEast ()
         {
             if(HasLocationToEast)
             {
-                CurrentLocation = CurrentWorld.LocationAt(CurrentLocation.XCoordinate + 1, CurrentLocation.YCoordinate);
+				MoveTo(CurrentLocation.XCoordinate + 1, CurrentLocation.YCoordinate);
             }
         }
 
-        public void MoveSouth()
+        public void AttemptMoveSouth ()
         {
             if(HasLocationToSouth)
             {
-                CurrentLocation = CurrentWorld.LocationAt(CurrentLocation.XCoordinate, CurrentLocation.YCoordinate - 1);
+				MoveTo(CurrentLocation.XCoordinate, CurrentLocation.YCoordinate - 1);
             }
         }
 
-        public void MoveWest()
+        public void AttemptMoveWest ()
         {
             if(HasLocationToWest)
             {
-                CurrentLocation = CurrentWorld.LocationAt(CurrentLocation.XCoordinate - 1, CurrentLocation.YCoordinate);
+                MoveTo(CurrentLocation.XCoordinate - 1, CurrentLocation.YCoordinate);
             }
         }
+
+        private void MoveTo(int xCoordinate, int yCoordinate) {
+            _currentBattle?.PlayerAttemptToEscapeCombat();
+            _currentBattle?.Dispose();
+
+			CurrentLocation = CurrentWorld.LocationAt(xCoordinate, yCoordinate);
+		}
 
         private void PopulateGameDetails()
         {

--- a/SOSCSRPG.ViewModels/GameSession.cs
+++ b/SOSCSRPG.ViewModels/GameSession.cs
@@ -225,9 +225,9 @@ namespace SOSCSRPG.ViewModels
             }
         }
 
-        private void MoveTo(int xCoordinate, int yCoordinate) {
+        private void MoveTo(int xCoordinate, int yCoordinate)
+        {
             _currentBattle?.PlayerAttemptToEscapeCombat();
-            _currentBattle?.Dispose();
 
 			CurrentLocation = CurrentWorld.LocationAt(xCoordinate, yCoordinate);
 		}
@@ -383,8 +383,19 @@ namespace SOSCSRPG.ViewModels
 
         private void OnCurrentMonsterKilled(object sender, System.EventArgs eventArgs)
         {
-            // Get another monster to fight
-            CurrentMonster = MonsterFactory.GetMonsterFromLocation(CurrentLocation);
+            // 2/3 Chance another monster appears to fight
+            if (DiceService.Instance.Roll(3).Value > 1)
+            {
+                CurrentMonster = MonsterFactory.GetMonsterFromLocation(CurrentLocation);
+            }
+            else
+            {
+                _currentBattle.Dispose();
+                CurrentMonster = null;
+
+                _messageBroker.RaiseMessage("");
+                _messageBroker.RaiseMessage("The area seems quiet, for now.");
+            }
         }
 
         private void OnCurrentPlayerLeveledUp(object sender, System.EventArgs eventArgs)

--- a/WPFUI/MainWindow.xaml.cs
+++ b/WPFUI/MainWindow.xaml.cs
@@ -45,22 +45,22 @@ namespace WPFUI
 
         private void OnClick_MoveNorth(object sender, RoutedEventArgs e)
         {
-            _gameSession.MoveNorth();
+            _gameSession.AttemptMoveNorth();
         }
 
         private void OnClick_MoveWest(object sender, RoutedEventArgs e)
         {
-            _gameSession.MoveWest();
+            _gameSession.AttemptMoveWest();
         }
 
         private void OnClick_MoveEast(object sender, RoutedEventArgs e)
         {
-            _gameSession.MoveEast();
+            _gameSession.AttemptMoveEast();
         }
 
         private void OnClick_MoveSouth(object sender, RoutedEventArgs e)
         {
-            _gameSession.MoveSouth();
+            _gameSession.AttemptMoveSouth();
         }
 
         private void OnClick_AttackMonster(object sender, RoutedEventArgs e)
@@ -92,10 +92,10 @@ namespace WPFUI
 
         private void InitializeUserInputActions()
         {
-            _userInputActions.Add(Key.W, () => _gameSession.MoveNorth());
-            _userInputActions.Add(Key.A, () => _gameSession.MoveWest());
-            _userInputActions.Add(Key.S, () => _gameSession.MoveSouth());
-            _userInputActions.Add(Key.D, () => _gameSession.MoveEast());
+            _userInputActions.Add(Key.W, () => _gameSession.AttemptMoveNorth());
+            _userInputActions.Add(Key.A, () => _gameSession.AttemptMoveWest());
+            _userInputActions.Add(Key.S, () => _gameSession.AttemptMoveSouth());
+            _userInputActions.Add(Key.D, () => _gameSession.AttemptMoveEast());
             _userInputActions.Add(Key.Z, () => _gameSession.AttackCurrentMonster());
             _userInputActions.Add(Key.C, () => _gameSession.UseCurrentConsumable());
             _userInputActions.Add(Key.P, () => _gameSession.PlayerDetails.IsVisible = !_gameSession.PlayerDetails.IsVisible);


### PR DESCRIPTION
First commit:
Adds an attack of opportunity for the opponent.
Renamed cardinal move functions (ie: MoveEast) to 'AttemptMoveEast'. This better reflects the ability to trigger these functions even when they are not currently valid (ie: using WASD to move). They now all call MoveTo(x, y).
GameSession.MoveTo calls Battle.PlayerAttemptToEscapeCombat(), which raises a message and provides an attack of opportunity to enemy, which can be expanded on in the future (preventing flee based on enemy or debuff, percentage chance to flee, etc).

Second commit:
There is now a 2/3 chance to spawn a new monster on opponent death.
Removed an unnecessary call to Battle.Dispose() I added in GameSession.MoveTo() on the first commit.

I spent the last few days following the series through Lesson 17 hand-typed, in my own copy of the project, which had unit testing. I am embarrassingly new to committing to open-source projects, but I do not see the unit tests on my fork of the master project. I would be happy to update testing for my commit(s), which the 'How to Contribute' says is required. Please advise me on how to view the current testing code in my project. I am using Github desktop.